### PR TITLE
Allow custom models to be visible during Battin' a Thousand

### DIFF
--- a/scripting/weaponmodel_override.sp
+++ b/scripting/weaponmodel_override.sp
@@ -361,16 +361,13 @@ public void TF2_OnConditionAdded(int iClient, TFCond cond)
     int iTaunt = GetEntProp(iClient, Prop_Send, "m_iTauntItemDefIndex");
     
     // Default taunt. We're keeping the model in case it uses the weapon ( ex: sniper's sniperrifle default taunt )
-    if(iTaunt < 0)
+    if(iTaunt < 0 || !g_hWeaponModels[iWeapon].HasModel())
         return;
  
     if(iTaunt == 1117) {  // Battin' a Thousand taunt
         OnDrawWeapon(iClient, iWeapon);
         return;
     }
-
-    if(!g_hWeaponModels[iWeapon].HasModel())
-        return;
 
     // Fun fact: Taunt props are somehow bound to weapons. You gotta unhide them 
     // or otherwise the taunt props will be invisible.

--- a/scripting/weaponmodel_override.sp
+++ b/scripting/weaponmodel_override.sp
@@ -363,6 +363,11 @@ public void TF2_OnConditionAdded(int iClient, TFCond cond)
     // Default taunt. We're keeping the model in case it uses the weapon ( ex: sniper's sniperrifle default taunt )
     if(iTaunt < 0)
         return;
+ 
+    if(iTaunt == 1117) {  // Battin' a Thousand taunt
+        OnDrawWeapon(iClient, iWeapon);
+        return;
+    }
 
     if(!g_hWeaponModels[iWeapon].HasModel())
         return;


### PR DESCRIPTION
Simply isn't necessary to hide it during this specific taunt, very minor detail but still.